### PR TITLE
Render text

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -35,8 +35,6 @@ module Mobiledoc
     end
 
     def render
-      root = create_document_fragment
-
       sections.each do |section|
         rendered = render_section(section)
 

--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -34,7 +34,7 @@ module Mobiledoc
       end
     end
 
-    def render
+    def populate_root
       sections.each do |section|
         rendered = render_section(section)
 
@@ -42,8 +42,16 @@ module Mobiledoc
           append_child(root, rendered)
         end
       end
+    end
 
+    def render
+      populate_root
       root.to_html(save_with: 0).gsub('  ', ' &nbsp;')
+    end
+
+    def render_text
+      populate_root
+      root.children.map(&:text).join("\n")
     end
 
     def create_document_fragment

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -66,17 +66,27 @@ module Mobiledoc
       end
     end
 
-    def render(mobiledoc)
+    def get_version_renderer(mobiledoc)
       version = mobiledoc['version']
 
       case version
       when '0.2.0'
-        Renderer_0_2.new(mobiledoc, state).render
+        Renderer_0_2.new(mobiledoc, state)
       when '0.3.0', '0.3.1', nil
-        Renderer_0_3.new(mobiledoc, state).render
+        Renderer_0_3.new(mobiledoc, state)
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])
       end
+    end
+
+    def render(mobiledoc)
+      version_renderer = get_version_renderer(mobiledoc)
+      version_renderer.render
+    end
+
+    def render_text(mobiledoc)
+      version_renderer = get_version_renderer(mobiledoc)
+      version_renderer.render_text
     end
   end
 end

--- a/spec/mobiledoc_html_renderer_spec.rb
+++ b/spec/mobiledoc_html_renderer_spec.rb
@@ -1,11 +1,62 @@
 require 'spec_helper'
 
+include Mobiledoc::Utils::SectionTypes
+include Mobiledoc::Utils::MarkerTypes
+
 describe Mobiledoc::HTMLRenderer do
+
   it 'has a version number' do
     expect(Mobiledoc::HTMLRenderer::VERSION).not_to be nil
   end
 
   it 'can be instantiated' do
     expect { described_class.new }.to_not raise_exception
+  end
+
+  describe '#render' do
+    it 'makes it easy to get raw text from a mobiledoc' do
+      expected_value = 'Bob'
+
+      atom = Module.new do
+        module_function
+
+        def name
+          'hello-atom'
+        end
+
+        def type
+          'html'
+        end
+
+        def render(env, value, payload, options)
+          "Hello #{value}"
+        end
+      end
+
+      mobiledoc = {
+        'version' => '0.3.1',
+        'atoms' => [
+          ['hello-atom', 'Bob', {}]
+        ],
+        'cards' => [],
+        'markups' => [],
+        'sections' => [
+          [MARKUP_SECTION_TYPE, 'P', [
+            [MARKUP_MARKER_TYPE, [], 0, 'Greeting: '],
+            [ATOM_MARKER_TYPE, [], 0, 0]]
+          ],
+          [MARKUP_SECTION_TYPE, 'P', [
+            [MARKUP_MARKER_TYPE, [], 0, 'Another line']]
+          ]
+        ]
+      }
+
+
+      renderer = Mobiledoc::HTMLRenderer.new(atoms: [atom])
+      text = renderer.render_text(mobiledoc)
+
+      expect(text).to eq("Greeting: Hello Bob\nAnother line")
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'pry'
 require 'mobiledoc_html_renderer'


### PR DESCRIPTION
Slight refactor + adds `#render_text` methods to the version renderers & renderer wrapper